### PR TITLE
Type-cast enums to `int` before comparison

### DIFF
--- a/lxroot.cpp
+++ b/lxroot.cpp
@@ -728,8 +728,8 @@ struct  Syscall  {    //  xxsy  -----------------------------  struct  Syscall
 
     //  the below verbose yet simple implementation should optimize well.
 
-    #define  if_equal(     a, b )  (   a == b                ? b : 0 )
-    #define  if_not_equal( a, b )  ( ( a != b ) && ( n & a ) ? b : 0 )
+    #define  if_equal(     a, b )  ( (int)a == (int)b                  ? b : 0 )
+    #define  if_not_equal( a, b )  ( ( (int)a != (int)b ) && ( n & a ) ? b : 0 )
 
     constexpr flags_t  copy_these_bits  =
       if_equal         (  ST_RDONLY,       MS_RDONLY       )


### PR DESCRIPTION
In glibc 2.33, `ST_*` and `MS_*` are enums, not macros: https://sourceware.org/git/?p=glibc.git;a=blob;f=bits/statvfs.h;h=998deca502aa5a67ae937a05e1c077b6c647b10c;hb=9826b03b747b841f5fc6de2054bf1ef3f5c4bdf3.  This means they need to be type-casted to `int` (or any other integer type) in order to compare them without getting a warning (which are fatal errors with `-Werror`).  Fixes #6.